### PR TITLE
Fix example not wrapped in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Humble/locstor
 
 [![GoDoc](https://godoc.org/github.com/go-humble/locstor?status.svg)](https://godoc.org/github.com/go-humble/locstor)
 
-Version X.X.X (develop)
+Version 0.1.0
 
 locstor provides gopherjs bindings for the localStorage API. It allows you to
 store and retrieve any arbitrary go data structure, and is intended to be

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@
 // allows you to store and retrieve any arbitrary go data structure, and is
 // intended to be compiled to javascript with gopherjs and run in the browser.
 //
-// Version X.X.X (develop)
+// Version 0.1.0
 //
 // For the full source code, example usage, and more information visit
 // https://github.com/go-humble/locstor.


### PR DESCRIPTION
Also fix a slight error in the example itself, not correctly checking the result of the type assertion.